### PR TITLE
Added del method to AbstractDisplay

### DIFF
--- a/pyvirtualdisplay/abstractdisplay.py
+++ b/pyvirtualdisplay/abstractdisplay.py
@@ -25,6 +25,11 @@ class AbstractDisplay(EasyProcess):
         self.display = self.search_for_display()
         EasyProcess.__init__(self, self._cmd)
 
+    def __del__(self):
+        # Stop the display on delete to avoid 
+        # "orphaned" dbus processes
+        self.stop()
+
     @property
     def new_display_var(self):
         return ':%s' % (self.display)


### PR DESCRIPTION
When a display object is deleted, the display should first be stopped to avoid any issues with orphaned processes related to the virtual display.

Issue noticed on an Ubuntu server using Xvfb.  Issue was not reproducible on an Ubuntu machine with a physical display.  Most simple reproduction in python terminal:
1. Import, start and use a display
2. Exit the python process with Ctrl-D
3. View running processes, there may be a dbus instance related to the display that will run indefinitely.
