### PR TITLE
add the ability to generate Xauthority files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -148,6 +148,15 @@ vncserver
               proc.wait()
   #-#
 
+xauth
+=====
+
+Some programs require a functional Xauthority file. PyVirtualDisplay can
+generate one and set the appropriate environment variables if you pass
+``use_xauth=True`` to the ``Display`` constructor. Note however that this
+feature needs ``xauth`` installed, otherwise a
+``pyvirtualdisplay.xauth.NotFoundError`` is raised.
+
 
 .. _setuptools: http://peak.telecommunity.com/DevCenter/EasyInstall
 .. _pip: http://pip.openplans.org/

--- a/pyvirtualdisplay/display.py
+++ b/pyvirtualdisplay/display.py
@@ -13,8 +13,9 @@ class Display(AbstractDisplay):
     :param bgcolor: background color ['black' or 'white']
     :param visible: True -> Xephyr, False -> Xvfb
     :param backend: 'xvfb', 'xvnc' or 'xephyr', ignores ``visible``
+    :param xauth: If a Xauthority file should be created.
     '''
-    def __init__(self, backend=None, visible=False, size=(1024, 768), color_depth=24, bgcolor='black', **kwargs):
+    def __init__(self, backend=None, visible=False, size=(1024, 768), color_depth=24, bgcolor='black', use_xauth=False, **kwargs):
         self.color_depth = color_depth
         self.size = size
         self.bgcolor = bgcolor
@@ -35,7 +36,7 @@ class Display(AbstractDisplay):
             color_depth=color_depth,
             bgcolor=bgcolor,
             **kwargs)
-        AbstractDisplay.__init__(self)
+        AbstractDisplay.__init__(self, use_xauth=use_xauth)
 
     @property
     def display_class(self):

--- a/pyvirtualdisplay/xauth.py
+++ b/pyvirtualdisplay/xauth.py
@@ -1,0 +1,37 @@
+'''Utility functions for xauth.'''
+import os
+import hashlib
+
+import easyprocess
+
+
+class NotFoundError(Exception):
+    '''Error when xauth was not found.'''
+    pass
+
+
+def is_installed():
+    '''
+    Return whether or not xauth is installed.
+    '''
+    try:
+        easyprocess.EasyProcess(['xauth', '-h']).check_installed()
+    except easyprocess.EasyProcessCheckInstalledError:
+        return False
+    else:
+        return True
+
+
+def generate_mcookie():
+    '''
+    Generate a cookie string suitable for xauth.
+    '''
+    data = os.urandom(16)  # 16 bytes = 128 bit
+    return hashlib.md5(data).hexdigest()
+
+
+def call(*args):
+    '''
+    Call xauth with the given args.
+    '''
+    easyprocess.EasyProcess(['xauth'] + list(args)).call()

--- a/tests/test_xauth.py
+++ b/tests/test_xauth.py
@@ -28,3 +28,4 @@ def test_xauth():
 
     display.stop()
     eq_(old_xauth, os.getenv('XAUTHORITY'))
+    ok_(not os.path.isfile(new_xauth))

--- a/tests/test_xauth.py
+++ b/tests/test_xauth.py
@@ -1,0 +1,30 @@
+import os
+
+import easyprocess
+
+from nose import SkipTest
+from nose.tools import ok_, eq_
+
+from pyvirtualdisplay import xauth
+from pyvirtualdisplay.display import Display
+
+
+def test_xauth():
+    '''
+    Test that a Xauthority file is created.
+    '''
+    if not xauth.is_installed():
+        raise SkipTest('This test needs xauth installed')
+    old_xauth = os.getenv('XAUTHORITY')
+    display = Display(visible=0, use_xauth=True)
+    display.start()
+    new_xauth = os.getenv('XAUTHORITY')
+
+    ok_(new_xauth is not None)
+    ok_(os.path.isfile(new_xauth))
+    filename = os.path.basename(new_xauth)
+    ok_(filename.startswith('PyVirtualDisplay.'))
+    ok_(filename.endswith('Xauthority'))
+
+    display.stop()
+    eq_(old_xauth, os.getenv('XAUTHORITY'))


### PR DESCRIPTION
Some programs need a Xauthority file present, which is not automatically
generated by Xvfb or Xephyr. This patch adds this ability with the
use_xauth parameter. If this parameter is True, PyVirtualDisplay will
generate a Xauthority file for the display and it will set the right
environment variables.

If xauth is not installed when use_xauth=True is given, a
pyvirtualdisplay.xauth.NotFoundError is raised.