### PR TITLE
Cast map() -> list to support Py2/3, allows len(ls) to work for Python 3 w/o breaking Python 2

### DIFF
--- a/pyvirtualdisplay/abstractdisplay.py
+++ b/pyvirtualdisplay/abstractdisplay.py
@@ -63,8 +63,8 @@ class AbstractDisplay(EasyProcess):
 
     def search_for_display(self):
         # search for free display
-        ls = map(
-            lambda x: int(x.split('X')[1].split('-')[0]), self.lock_files())
+        ls = list(map(
+            lambda x: int(x.split('X')[1].split('-')[0]), self.lock_files()))
         if len(ls):
             display = max(MIN_DISPLAY_NR, max(ls) + 3)
         else:


### PR DESCRIPTION
`map()` in Python 3 is a lazy generator, meaning it has no length. In Python 2, `map()` produced a `list` which does possess a length.

Without this change, the example in the README.rst fails on OSX/XQuartz Python 3.6 installation. 

This PR casts the `map()` generator to a list. 

Proof that this is of negligible penalty:

```
 (cpython36) benjolitz-laptop:~/software/PyVirtualDisplay [master]$ python -m timeit -s 'item = []' 'item = list(item)'
10000000 loops, best of 3: 0.182 usec per loop
```

I don't think anyone will cry about losing 0.182 microseconds. They might cry about pyvirtualdisplay throwing a `TypeError: object of type 'map' has no len()`