### PR TITLE
Start testing on Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
  - "3.3"
  - "3.4"
  - "3.5"
+ - "3.6"
 
 before_install:
   - sudo apt-get update -qq

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 
 [tox]
-envlist = py27,py33,py34,py35
+envlist = py27,py33,py34,py35,py36
 
 [testenv]
 changedir=tests


### PR DESCRIPTION
Python 3.3 goes [EOL](https://docs.python.org/devguide/index.html#branchstatus) later this month.