### PR TITLE
Check own display started

### DIFF
--- a/pyvirtualdisplay/abstractdisplay.py
+++ b/pyvirtualdisplay/abstractdisplay.py
@@ -144,7 +144,7 @@ class AbstractDisplay(EasyProcess):
 
         d = self.new_display_var
         ok = False
-        while time.time() - start_time < X_START_TIMEOUT:
+        while True:
             try:
                 exit_code = EasyProcess('xdpyinfo').call().return_code
             except EasyProcessError:
@@ -160,6 +160,8 @@ class AbstractDisplay(EasyProcess):
                 ok = True
                 break
 
+            if time.time() - start_time >= X_START_TIMEOUT:
+                break
             time.sleep(X_START_TIME_STEP)
         if not ok:
             msg = 'Failed to start X on display "%s" (xdpyinfo check failed).'

--- a/pyvirtualdisplay/display.py
+++ b/pyvirtualdisplay/display.py
@@ -57,5 +57,6 @@ class Display(AbstractDisplay):
     def _cmd(self):
         self._obj.display = self.display
         self._obj.check_startup = self.check_startup
-        self._obj.check_startup_fd = self.check_startup_fd
+        if self.check_startup:
+            self._obj.check_startup_fd = self.check_startup_fd
         return self._obj._cmd

--- a/pyvirtualdisplay/display.py
+++ b/pyvirtualdisplay/display.py
@@ -15,7 +15,7 @@ class Display(AbstractDisplay):
     :param backend: 'xvfb', 'xvnc' or 'xephyr', ignores ``visible``
     :param xauth: If a Xauthority file should be created.
     '''
-    def __init__(self, backend=None, visible=False, size=(1024, 768), color_depth=24, bgcolor='black', use_xauth=False, **kwargs):
+    def __init__(self, backend=None, visible=False, size=(1024, 768), color_depth=24, bgcolor='black', use_xauth=False, check_startup=False, **kwargs):
         self.color_depth = color_depth
         self.size = size
         self.bgcolor = bgcolor
@@ -36,7 +36,7 @@ class Display(AbstractDisplay):
             color_depth=color_depth,
             bgcolor=bgcolor,
             **kwargs)
-        AbstractDisplay.__init__(self, use_xauth=use_xauth)
+        AbstractDisplay.__init__(self, use_xauth=use_xauth, check_startup=check_startup)
 
     @property
     def display_class(self):
@@ -56,4 +56,6 @@ class Display(AbstractDisplay):
     @property
     def _cmd(self):
         self._obj.display = self.display
+        self._obj.check_startup = self.check_startup
+        self._obj.check_startup_fd = self.check_startup_fd
         return self._obj._cmd

--- a/pyvirtualdisplay/xephyr.py
+++ b/pyvirtualdisplay/xephyr.py
@@ -38,4 +38,6 @@ class XephyrDisplay(AbstractDisplay):
                '-resizeable',
                self.new_display_var,
                ]
+        if self.check_startup:
+            cmd += ['-displayfd', str(self.check_startup_fd)]
         return cmd

--- a/pyvirtualdisplay/xvfb.py
+++ b/pyvirtualdisplay/xvfb.py
@@ -50,4 +50,6 @@ class XvfbDisplay(AbstractDisplay):
                ]
         if self.fbdir:
             cmd += ['-fbdir', self.fbdir]
+        if self.check_startup:
+            cmd += ['-displayfd', str(self.check_startup_fd)]
         return [PROGRAM] + cmd

--- a/pyvirtualdisplay/xvnc.py
+++ b/pyvirtualdisplay/xvnc.py
@@ -40,4 +40,6 @@ class XvncDisplay(AbstractDisplay):
                '-rfbport', str(self.rfbport),
                self.new_display_var,
                ]
+        if self.check_startup:
+            cmd += ['-displayfd', str(self.check_startup_fd)]
         return cmd


### PR DESCRIPTION
- needed to avoid race conditions when multiple scripts start a X server simultaniously where neighter pre-check will see lock file of the other process not the xdpyinfo check indicates error because he simply rans with X server belonging to different process
(see also issue #33)

- currently the python 3 implementation is possibly incomplete as the EasyProcess module currently does not provide a way to inherit the needed fd on path on >= 3.2
--> here the EasyProcess needs to pass eigther "close_fds=False" to subprocess.Popen to re-enable expected previous behaviour of inhereting the fds based on there CLOEXEC mode and/or to allow to pass specific fds to sub-processes via "pass_fds=()" argument of Popen. depending on implementation the display may need to pass the instruction to pass the "displayfd" to EasyProcess...

- possibly this check should be made default, but I want to avoid bad looking failing travis CI checks because of the missing EasyProcess functionality for py3...