### PR TITLE
Added the -rfbauth flag to the Xvnc command

### DIFF
--- a/pyvirtualdisplay/xvnc.py
+++ b/pyvirtualdisplay/xvnc.py
@@ -13,7 +13,7 @@ class XvncDisplay(AbstractDisplay):
     '''
     Xvnc wrapper
     '''
-    def __init__(self, size=(1024, 768), color_depth=24, bgcolor='black', rfbport=5900):
+    def __init__(self, size=(1024, 768), color_depth=24, bgcolor='black', rfbport=5900, rfbauth=''):
         '''
         :param bgcolor: 'black' or 'white'
         :param rfbport: Specifies the TCP port on which Xvnc listens for connections from viewers (the protocol used in VNC is called RFB - "remote framebuffer"). The default is 5900 plus the display number.
@@ -25,6 +25,7 @@ class XvncDisplay(AbstractDisplay):
         self.bgcolor = bgcolor
         self.display = None
         self.rfbport = rfbport
+        self.rfbauth = rfbauth
         AbstractDisplay.__init__(self)
 
     @classmethod
@@ -38,6 +39,7 @@ class XvncDisplay(AbstractDisplay):
                '-depth', str(self.color_depth),
                '-geometry', '%dx%d' % (self.size[0], self.size[1]),
                '-rfbport', str(self.rfbport),
+               '-rfbauth', str(self.rfbauth),
                self.new_display_var,
                ]
         return cmd

--- a/pyvirtualdisplay/xvnc.py
+++ b/pyvirtualdisplay/xvnc.py
@@ -17,6 +17,7 @@ class XvncDisplay(AbstractDisplay):
         '''
         :param bgcolor: 'black' or 'white'
         :param rfbport: Specifies the TCP port on which Xvnc listens for connections from viewers (the protocol used in VNC is called RFB - "remote framebuffer"). The default is 5900 plus the display number.
+        :param rfbauth: Specifies the file containing the password used to authenticate viewers.
         '''
         self.screen = 0
         self.size = size


### PR DESCRIPTION
Allows the use of password authentication with Xvnc, as suggested in #19 .
The default rfbauth value is set to '', which is the default listed in Xvnc's documentation.