### PR TITLE
upgrade easyprocess to 0.3.0 when pyvirtualdisplay is 0.2.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,10 @@ __version__ = None
 exec(open(os.path.join(NAME, "about.py")).read())
 VERSION = __version__
 
+easy_process = "EasyProcess"
+if VERSION >= '0.2.5':
+    easy_process = "EasyProcess>=0.3.0"
+
 # extra = {}
 # if sys.version_info >= (3,):
 #     extra['use_2to3'] = True
@@ -38,7 +42,7 @@ classifiers = [
     "Programming Language :: Python :: 3.8",
 ]
 
-install_requires = ["EasyProcess"]
+install_requires = [easy_process]
 
 setup(
     name=PYPI_NAME,


### PR DESCRIPTION
hi, really glad to create this pull request. My company is using this lib for selenium headless test for thousands of cases.  It really helped us.

Recently my test engineer reported to me that part of cases were failed with pyvirtualdisplay newest version 0.2.5 need easyprocess 0.3.0. But if the easyprocess old version has been already there, upgrading pyvirtualdisplay will not automatically upgrade easyprocess. So I think this maybe need fixed. 

Finally, thx for your work again,it's greate.