### PR TITLE
Fix hanging pipe

### DIFF
--- a/pyvirtualdisplay/abstractdisplay.py
+++ b/pyvirtualdisplay/abstractdisplay.py
@@ -189,15 +189,15 @@ class AbstractDisplay(object):
                 self._subproc = subprocess.Popen(
                     self._command,
                     pass_fds=[self._pipe_wfd],
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
                     shell=False,
                 )
             else:
                 self._subproc = subprocess.Popen(
                     self._command,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
                     shell=False,
                 )
 
@@ -340,7 +340,6 @@ class AbstractDisplay(object):
                 log.debug("exception in kill:%s", oserror)
 
             self._subproc.wait()
-            self._read_stdout_stderr()
 
     def stop(self):
         """
@@ -364,13 +363,6 @@ class AbstractDisplay(object):
                 _USED_DISPLAY_NR_LIST.remove(self._display_to_rm)
                 self._display_to_rm = None
         return self
-
-    def _read_stdout_stderr(self):
-        if self.stdout is None:
-            (self.stdout, self.stderr) = self._subproc.communicate()
-
-            log.debug("stdout=%s", self.stdout)
-            log.debug("stderr=%s", self.stderr)
 
     def _setup_xauth(self):
         """
@@ -416,9 +408,6 @@ class AbstractDisplay(object):
             return False
         # return self.return_code is None
         rc = self._subproc.poll()
-        if rc is not None:
-            # proc exited
-            self._read_stdout_stderr()
         return rc is None
 
     # @property


### PR DESCRIPTION
fixes #92 

The problem causing the issue above is that `Xvfb` started to be a lot more chatty. Using it with `chrome` it keeps outputing the following on each connection:

```sh
1 XSELINUXs still allocated at reset
SCREEN: 0 objects of 304 bytes = 0 total bytes 0 private allocs
DEVICE: 0 objects of 88 bytes = 0 total bytes 0 private allocs
CLIENT: 0 objects of 136 bytes = 0 total bytes 0 private allocs
WINDOW: 0 objects of 48 bytes = 0 total bytes 0 private allocs
PIXMAP: 0 objects of 16 bytes = 0 total bytes 0 private allocs
GC: 0 objects of 16 bytes = 0 total bytes 0 private allocs
CURSOR: 1 objects of 8 bytes = 8 total bytes 0 private allocs
TOTAL: 1 objects, 8 bytes, 0 allocs
1 CURSORs still allocated at reset
CURSOR: 1 objects of 8 bytes = 8 total bytes 0 private allocs
TOTAL: 1 objects, 8 bytes, 0 allocs
1 CURSOR_BITSs still allocated at reset
TOTAL: 0 objects, 0 bytes, 0 allocs
```

So there is a lot of data going through stderr if we make a lot of connection to the display. And currently the library assigns stdout and stderr to a subprocess `PIPE` but doesn't read from it until it stops it. Hence all this data is buffered and when the buffer is full it hangs the execution of the whole program.

I am not sure if what I propose is the best solution but it seems that the `PIPE`s aren't actually used, only to debug log everything at the end. Another solution could be to (optionally?) redirect stdout/stderr to a log file if we want to keep the debug data. Would be neat if we could redirect to a logger directly but unfortunately I don't think it is really possible in python.